### PR TITLE
wip: updating to the new web3.storage api

### DIFF
--- a/src-ts/config-related.ts
+++ b/src-ts/config-related.ts
@@ -120,8 +120,16 @@ export async function createLanguage(languageName: string,
     console.log("Language record " + languageName + " created successfully!");
 }
 
-export async function setweb3token(token: string) {
+/*export async function setweb3token(token: string) {
     await iv.config.write("my-web3.storage-api-token", token);
+}*/
+
+export async function setw3email(email: string) {
+    await iv.config.write("my-w3-email", email);
+}
+
+export async function setw3space(space: string) {
+    await iv.config.write("my-w3-space", space);
 }
 
 export async function setgateway(gateway: string) {

--- a/src-ts/index.ts
+++ b/src-ts/index.ts
@@ -19,8 +19,7 @@
 
 import { program } from 'commander';
 import { publishCommand } from './publish.js';
-import { createAgent, createTool, createLanguage, setweb3token,
-         setgateway, listconfig } from './config-related.js';
+import { createAgent, createTool, createLanguage, setw3email, setw3space, setgateway, listconfig } from './config-related.js';
 import { getCommand } from './get.js';
 //import { trustwhoCommand } from './trusting';
 //import { whatISay, doISay } from './trusting-old';
@@ -46,12 +45,22 @@ program
     .argument('<input-type>', 'type for your input: takes "file" for a text input, "json" or "cid".\n')
     .argument('<input>', 'the input for the created language record. A filepath or cid.\n')
     .action(createLanguage);
-program
+/*program
     .command('set-web3token')
     .description('set your web3.storage api token.\n')
     .argument('<token>', 'to use for publishing through the web3.storage api.\n'
     + 'you can create one at web3.storage website.\n')
-    .action(setweb3token);
+    .action(setweb3token);*/
+program
+    .command('set-w3-email')
+    .description('set your web3.storage account login email.\n')
+    .argument('<email>', 'to use to access your web3.storage account and upload data.\n')
+    .action(setw3email)
+program
+    .command('set-w3-space')
+    .description('set your web3.storage space key.\n')
+    .argument('<key>', 'the key for the desired console.web3.storage space for uploading data.\n')
+    .action(setw3space)
 program
     .command('set-gateway')
     .description('set your gateway.\n')


### PR DESCRIPTION
wip (though basic usage and test works for now).
Will need to update the documentation site also before FCJ2024 archival.
This update just assumes that a user would create a personal account and use it, though later, there could be more to be done and said (delegations, etc: check https://web3.storage/docs/concepts/architecture-options/).